### PR TITLE
Allow the use of absolute paths in config file

### DIFF
--- a/hastie.go
+++ b/hastie.go
@@ -426,9 +426,9 @@ func readParseFile(filename string) (page Page) {
 
 	}
 
-	// chop off first directory, since that is the template dir
+	// generate the public-file's path based on the source-file's path
 	log.Debug("Filename", filename)
-	page.OutFile = filename[strings.Index(filename, string(os.PathSeparator))+1:]
+	page.OutFile = filename[strings.Index(filename, config.SourceDir) + len(config.SourceDir):]
 	page.OutFile = strings.Replace(page.OutFile, ".md", page.Extension, 1)
 	log.Debug("page.Outfile", page.OutFile)
 


### PR DESCRIPTION
When reading files in `Config.SourceDir` ensure that absolute path names are translated correctly into their `Config.PublishDir` equivalents.