### PR TITLE
.Recent.Limit func can no longer produce slice out-of-bounds errors

### DIFF
--- a/hastie.go
+++ b/hastie.go
@@ -71,7 +71,10 @@ func (p PagesSlice) Len() int               { return len(p) }
 func (p PagesSlice) Less(i, j int) bool     { return p[i].Date.Unix() < p[j].Date.Unix() }
 func (p PagesSlice) Swap(i, j int)          { p[i], p[j] = p[j], p[i] }
 func (p PagesSlice) Sort()                  { sort.Sort(p) }
-func (p PagesSlice) Limit(n int) PagesSlice { return p[0:n] }
+func (p PagesSlice) Limit(n int) PagesSlice {
+	if len(p) > n { return p[0:n] }
+	return p
+}
 func (p PagesSlice) Reverse() PagesSlice {
 	var rev PagesSlice
 	for i := len(p) - 1; i >= 0; i-- {


### PR DESCRIPTION
If passed with a high `n` (or a small number of posts) `.Recent.Limit` had the potential to break pages because of an out-of-bounds slice access; now the slice length is checked to ensure it will not trigger that access error.